### PR TITLE
Update contributing documentation to include the step to initialize the submodule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing
 
 This guide will help you set yourself up to contribute code to this project.
+See the [user manual](https://smartergridsolutions.github.io/openfmb-device-simulator/)
+if you simply want to use the OpenFMB Device Simulator.
 
 ## Prerequisites
 
@@ -10,6 +12,20 @@ You need to have the following installed on your development machine:
 * NATS 2.x
 
 (Our tests run on both environment, so you need both installed).
+
+## Clone the Repository
+
+Run the following in a terminal to clone the repository and its submodules:
+
+```sh
+git clone --recursive https://gitlab.com/smatergridsolutions/openfmb-device-simulator.git
+```
+
+If you already have cloned the repository and did not clone recursively, you can clone the submodules with:
+
+```sh
+git submodule update --init --recursive
+```
 
 ## Build and Run
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -45,7 +45,8 @@ async def test_index_returns_page(test_app):
     test_client = test_app.test_client()
     response = await test_client.get("/")
     assert response.status_code == 200
-    body = await response.get_data(raw=False)
+    body = await response.get_data(as_text=True)
+    print(body)
     assert "<html>" in body
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -46,7 +46,6 @@ async def test_index_returns_page(test_app):
     response = await test_client.get("/")
     assert response.status_code == 200
     body = await response.get_data(as_text=True)
-    print(body)
     assert "<html>" in body
 
 


### PR DESCRIPTION
The steps in contributing leave out that you need to initialize the submodule. This leads to hard to diagnose issues. This change make initializing the submodule a called out step.